### PR TITLE
Add share image link action to posts

### DIFF
--- a/Pr0gramm/Pr0gramm/Detail/DetailViewController.swift
+++ b/Pr0gramm/Pr0gramm/Detail/DetailViewController.swift
@@ -286,11 +286,15 @@ extension DetailViewController: UIContextMenuInteractionDelegate {
             self.coordinator?.showShareSheet(with: [self.viewModel.shareLink], from: imageView)
         }
         
+        let shareImageAction = UIAction(title: "Bild-Link teilen", image: UIImage(systemName: "square.and.arrow.up")) { [unowned self] _ in
+            self.coordinator?.showShareSheet(with: [self.viewModel.item.url], from: imageView)
+        }
+        
         let browserAction = UIAction(title: "Im Browser öffnen", image: UIImage(systemName: "safari")) { [unowned self] _ in
             UIApplication.shared.open(self.viewModel.shareLink)
         }
 
-        return UIMenu(title: "", children: [downloadAction, fullscreenAction, saveToCameraRollAction, shareAction, browserAction])
+        return UIMenu(title: "", children: [downloadAction, fullscreenAction, saveToCameraRollAction, shareAction, shareImageAction, browserAction])
     }
 }
 


### PR DESCRIPTION
add a share image link action to long press menu on post viewer

previews are generated for direct links in many rich text messengers so this is "basically" sharing the file while simultaneously allowing sharing with non-members of the community.