### PR TITLE
Always use UserDefaults from AppSettings & Improve SwiftUI logic

### DIFF
--- a/Pr0gramm/Pr0gramm/PostCountSelectionView.swift
+++ b/Pr0gramm/Pr0gramm/PostCountSelectionView.swift
@@ -1,27 +1,18 @@
 import SwiftUI
 
 struct PostCountSelectionView: View {
-    @AppStorage("postCount") private var postCount: Int = 3
-    @State private var postCountState: Int = 0
+    @AppStorage(#keyPath(AppSettings.postCount)) private var postCount: Int = AppSettings.postCount
 
     var body: some View {
-        Picker("Post Count", selection: $postCountState) {
+        Picker("Post Count", selection: $postCount) {
             ForEach(3 ..< 7) { count in
-                Text(String(count))
+                Text(String(count)).tag(count)
             }
         }
         .pickerStyle(.segmented)
-        .onChange(of: postCountState) { newValue in
-            postCount = postCountState + 3
-        }
-        .onAppear {
-            postCountState = postCount - 3
-        }
     }
 }
 
-struct PostCountSelectionView_Previews: PreviewProvider {
-    static var previews: some View {
-        PostCountSelectionView()
-    }
+#Preview {
+    PostCountSelectionView()
 }

--- a/Pr0gramm/Pr0gramm/SettingsViewController.swift
+++ b/Pr0gramm/Pr0gramm/SettingsViewController.swift
@@ -1,47 +1,24 @@
-
-@propertyWrapper
-struct CodableAppStorage<T: Codable> {
-    let key: String
-    let defaultValue: T
-
-    init(_ key: String, defaultValue: T) {
-        self.key = key
-        self.defaultValue = defaultValue
-    }
-
-    var wrappedValue: T {
-        get {
-            guard let data = UserDefaults.standard.data(forKey: key),
-                  let value = try? JSONDecoder().decode(T.self, from: data) else {
-                return defaultValue
-            }
-            return value
-        }
-        set {
-            if let data = try? JSONEncoder().encode(newValue) {
-                UserDefaults.standard.set(data, forKey: key)
-            }
-        }
-    }
-}
-
 import SwiftUI
 import StoreKit
 
 struct SettingsView: View {
     @State private var isOverlayShown = false
 
-    @AppStorage("selectedTheme") var selectedTheme: Int = 1
-    @AppStorage("isLoggedIn") var isLoggedIn: Bool = false
-    @AppStorage("isVideoMuted") var isVideoMuted: Bool = false
-    @AppStorage("isAutoPlay") var isAutoPlay: Bool = true
-    @AppStorage("isShowSeenBagdes") var isShowSeenBagdes: Bool = true
-    @AppStorage("isPictureInPictureEnabled") var isPictureInPictureEnabled: Bool = true
-    @AppStorage("postCount") var postCount: Int = 4
-    @AppStorage("isMediaHeightLimitEnabled") var isMediaHeightLimitEnabled: Bool = false
-    @AppStorage("isDeactivateNsfwOnAppStart") var isDeactivateNsfwOnAppStart: Bool = false
-    @AppStorage("isMuteOnUnnecessaryMusic") var isMuteOnUnnecessaryMusic: Bool = false
-    @CodableAppStorage("latestSearchStrings", defaultValue: []) var latestSearchStrings: [String]
+    @AppStorage(#keyPath(AppSettings.isShowSeenBagdes))
+    var isShowSeenBagdes: Bool = AppSettings.isShowSeenBagdes
+    @AppStorage(#keyPath(AppSettings.isMediaHeightLimitEnabled))
+    var isMediaHeightLimitEnabled: Bool = AppSettings.isMediaHeightLimitEnabled
+    @AppStorage(#keyPath(AppSettings.isDeactivateNsfwOnAppStart))
+    var isDeactivateNsfwOnAppStart: Bool = AppSettings.isDeactivateNsfwOnAppStart
+  
+    @AppStorage(#keyPath(AppSettings.isVideoMuted))
+    var isVideoMuted: Bool = AppSettings.isVideoMuted
+    @AppStorage(#keyPath(AppSettings.isAutoPlay))
+    var isAutoPlay: Bool = AppSettings.isAutoPlay
+    @AppStorage(#keyPath(AppSettings.isPictureInPictureEnabled))
+    var isPictureInPictureEnabled: Bool = AppSettings.isPictureInPictureEnabled
+    @AppStorage(#keyPath(AppSettings.isMuteOnUnnecessaryMusic))
+    var isMuteOnUnnecessaryMusic: Bool = AppSettings.isMuteOnUnnecessaryMusic
 
     var body: some View {
         NavigationView {
@@ -65,7 +42,11 @@ struct SettingsView: View {
                     Toggle("Gesehen Indikator anzeigen", isOn: $isShowSeenBagdes)
                     Toggle("Medien auf Bildschirmhöhe begrenzen", isOn: $isMediaHeightLimitEnabled)
                     Toggle("NSFW/NSFL bei Appstart deaktivieren", isOn: $isDeactivateNsfwOnAppStart)
-                    Text("Datenbank: \(ActionsManager.shared.dataBaseSize ?? "Fehler")")
+                    HStack {
+                        Text("Datenbank")
+                        Spacer()
+                        Text(ActionsManager.shared.dataBaseSize ?? "Fehler").foregroundStyle(.secondary)
+                    }
                 }
                 
                 Section(header: Text("Video")) {
@@ -87,4 +68,8 @@ struct SettingsView: View {
             overlay.present(in: scene)
         }
     }
+}
+
+#Preview {
+    SettingsView()
 }

--- a/Pr0gramm/Pr0gramm/ThemeSelectionView.swift
+++ b/Pr0gramm/Pr0gramm/ThemeSelectionView.swift
@@ -1,8 +1,7 @@
-
 import SwiftUI
 
 struct ThemeSelectionView: View {
-    @AppStorage("selectedTheme") private var selectedTheme: Int = 0
+    @AppStorage(#keyPath(AppSettings.selectedTheme)) private var selectedTheme: Int = AppSettings.selectedTheme
 
     let themes = ["Blau", "Orange", "Grün", "Pink", "Gelb"]
 
@@ -19,8 +18,6 @@ struct ThemeSelectionView: View {
     }
 }
 
-struct ThemeSelectionView_Previews: PreviewProvider {
-    static var previews: some View {
-        ThemeSelectionView()
-    }
+#Preview {
+    ThemeSelectionView()
 }


### PR DESCRIPTION
PostCount & ThemeSelection hatten die falschen Defaultwerte, wodurch die Anzeige nicht korrekt war.
`@AppStorage` refererenziert nun immer die AppSettings, wo die tatsächlichen UserDefaults definiert werden.

(+ Ein paar SwiftUI Verbesserungen)