### PR TITLE
Fix feed for unregistered users and default filter settings

### DIFF
--- a/Pr0gramm/Pr0gramm/Settings.swift
+++ b/Pr0gramm/Pr0gramm/Settings.swift
@@ -69,14 +69,13 @@ extension AppSettings: FlagFilterSettingsConfigurable {
 
     static var currentFlags: [Flags] {
         var flags: [Flags] = []
-        guard AppSettings.isLoggedIn else { return [.sfw, .pol] }
+        guard AppSettings.isLoggedIn else { return [.sfw] }
         if AppSettings.sfwActive { flags.append(.sfw); flags.append(.nsfp) }
         if AppSettings.nsfwActive { flags.append(.nsfw) }
         if AppSettings.nsflActive { flags.append(.nsfl) }
         if AppSettings.polActive { flags.append(.pol) }
         guard !flags.isEmpty else {
             AppSettings.sfwActive = true
-            AppSettings.polActive = true
             return self.currentFlags
         }
         return flags


### PR DESCRIPTION
POL Filter ist nun nur noch für registrierte Nutzer einsehbar, daher wurde der Feed mit der bisherigen Standardeinstellung nicht geladen.

Weiters ist die Standard-Filtereinstellung der Website nun nur noch "SFW".